### PR TITLE
Rework microsteps, speed, and improve documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. This module
 - Account for microsteps in step <-> dist conversion
 - Make speed independent of microsteps setting
 - Remove accel/decel methods from StepperBase and move to TicStepper
+- Add additional documentation
+- Create hardware testing script for evaluating method behavior on RPi
 
 ## 0.1.0
 - Add accel/decel method to StepperBase with tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,14 @@
 # Relase notes
 
 All notable changes to this project will be documented in this file. This module adheres to [Semantic Versioning](https://semver.org/).
-## 0.0.2
+## 1.0.0
+- Replace steps_per_second with rpm
+- Replace units_per_second with dist_per_min
+- Account for microsteps in step <-> dist conversion
+- Make speed independent of microsteps setting
+- Remove accel/decel methods from StepperBase and move to TicStepper
+
+## 0.1.0
 - Add accel/decel method to StepperBase with tests
 - Add _setAccel and _setDecel methods to TicStepper with tests
 - Fix StepperBase method `stop`

--- a/pymotors/tic_stepper.py
+++ b/pymotors/tic_stepper.py
@@ -164,10 +164,10 @@ class TicStepper(StepperBase):
             warnings.warn('Limit switch not available in direction: ' + dir)
 
     def isHomed(self):
-        """
-        Check the 'position uncertain' bit on the Tic driver. The flag
-        'position uncertain' will be 1 if the motor is de-energized, commanded
-        to 'halt and hold', or contacts a limit switch. Home to clear the flag.
+        """Check the 'position uncertain' bit on the Tic driver.
+
+        The flag 'position uncertain' will be 1 if the motor is de-energized
+        or contacts a limit switch. Home to clear the flag.
 
         Returns
         -------
@@ -221,15 +221,19 @@ class TicStepper(StepperBase):
     @property
     def accel_decel(self) -> list:
         """Acceleration and deceleration values."""
-        return [self._accel, self._decel]
+        curr_accel = self.com.send(self._command_dict['gVariable'],
+                                   self._variable_dict['max_accel'])
+        curr_decel = self.com.send(self._command_dict['gVariable'],
+                                   self._variable_dict['max_decel'])
+        return [curr_accel, curr_decel]
 
     @accel_decel.setter
     def accel_decel(self, accel_decel_vals: list):
         if accel_decel_vals[0] > 0 and accel_decel_vals[1] > 0:
-            self._accel = accel_decel_vals[0]
-            self._decel = accel_decel_vals[1]
-            self._setAccel(self._accel)
-            self._setDecel(self._decel)
+            accel = accel_decel_vals[0]
+            decel = accel_decel_vals[1]
+            self._setAccel(accel)
+            self._setDecel(decel)
         else:
             warnings.warn("Acceleration and/or deceleration must be > 0")
 

--- a/pymotors/tic_stepper.py
+++ b/pymotors/tic_stepper.py
@@ -118,7 +118,7 @@ class TicStepper(StepperBase):
                  address=None,
                  input_dist_per_rev=1,
                  input_steps_per_rev=200,
-                 input_rpm=10):
+                 input_rpm=1):
 
         if self._communicationProtocol(type) == self._com_protocol['SERIAL']:
             port_name = port_params[0]  # ex: '/dev/ttyacm0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="pymotors",
-    version="0.0.1",
+    version="0.0.3",
     author="Robert R. Puccinelli",
     author_email="robert.puccinelli@outlook.com",
     description="Motor utilities for general use.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="pymotors",
-    version="0.0.3",
+    version="1.0.0",
     author="Robert R. Puccinelli",
     author_email="robert.puccinelli@outlook.com",
     description="Motor utilities for general use.",

--- a/tests/raspi_testing.py
+++ b/tests/raspi_testing.py
@@ -4,9 +4,14 @@ import pymotors
 
 
 def eval_tic(tic):
-    """Short testing script to confirm functionality."""
+    """Short testing script to confirm functionality.
+
+    Note: Ending position will not equal starting position due to converting
+    from full steps to microsteps when not at position 0. Also, to help with
+    visualizing motor movement, tape the end of the rotor.
+
+    """
     print('WARNING! MOTOR ROTOR MUST BE DECOUPLED FROM SYSTEM BEFORE TESTING')
-#    print('Tape on the motor shaft will help visualize motion.')
     sleep(2)
     print('Press `CTL-C` to abort.')
     print('Beginning in:')

--- a/tests/raspi_testing.py
+++ b/tests/raspi_testing.py
@@ -8,7 +8,7 @@ def eval_tic(tic):
     print('WARNING! MOTOR ROTOR MUST BE DECOUPLED FROM SYSTEM BEFORE TESTING')
 #    print('Tape on the motor shaft will help visualize motion.')
     sleep(2)
-    print('Motor will begin moving shortly. Press `CTL-C` to abort.')
+    print('Press `CTL-C` to abort.')
     print('Beginning in:')
     print('3')
     sleep(1)

--- a/tests/raspi_testing.py
+++ b/tests/raspi_testing.py
@@ -42,7 +42,7 @@ def eval_tic(tic):
 
     print('Updating accel/decel + moving to position 0.')
     sleep(1)
-    tic.accel_decel = [0x70000000, 0x70000000]
+    tic.accel_decel = [0x00700000, 0x00700000]
     tic.moveAbsDist(0)
     wait_for_motor(tic)
 
@@ -68,11 +68,13 @@ def eval_tic(tic):
 
 def wait_for_motor(motor):
     """Wait for motor to finish moving."""
-    sleep(.1)
-    while motor.isMoving():
-        sleep(.2)
-#        print('Current position: {}'.format(motor._position_in_steps()))
-        sleep(.1)
+    moving = 1
+    while moving:
+        sleep(0.2)
+        try:
+            moving = motor.isMoving()
+        except OSError:
+            moving = 1
 
 
 if __name__ == '__main__':

--- a/tests/raspi_testing.py
+++ b/tests/raspi_testing.py
@@ -1,10 +1,13 @@
+"""Evaluate Tic stepper driver with a Raspberry Pi."""
 from time import sleep
 import pymotors
 
 
-def eval_tic(tic: pymotors.TicStepper):
+def eval_tic(tic):
     """Short testing script to confirm functionality."""
-    print('Tape on the motor shaft will help visualize motion.')
+    print('WARNING! MOTOR ROTOR MUST BE DECOUPLED FROM SYSTEM BEFORE TESTING')
+#    print('Tape on the motor shaft will help visualize motion.')
+    sleep(2)
     print('Motor will begin moving shortly. Press `CTL-C` to abort.')
     print('Beginning in:')
     print('3')
@@ -17,41 +20,41 @@ def eval_tic(tic: pymotors.TicStepper):
     print('Enabling motor.')
     sleep(1)
     tic.enable = True
+    tic.microsteps = 1
 
-    print('Moving clockwise at default speed for 100 steps.')
+    print('Moving clockwise at default speed for 50 steps.')
     sleep(1)
-    tic.moveAbsSteps(100)
+    tic.moveAbsSteps(50)
     wait_for_motor(tic)
 
-    print('Changing velocity to 10 RPM + moving 200 steps counter clockwise.')
+    print('Changing velocity to 10 RPM + moving 250 steps counter clockwise.')
     sleep(1)
     tic.rpm = 10
-    tic.moveRelSteps(-200)
+    tic.moveRelSteps(-250)
     wait_for_motor(tic)
 
-    print('Changing microsteps to 1/8 + moving 200 steps clockwise.')
-    print('NOTE: Speed should not change when using microsteps.')
+    print('Changing microsteps to 1/8 + moving 800 steps clockwise.')
+    print('NOTE: RPM should not change when using microsteps.')
     sleep(1)
     tic.microsteps = 1/8
-    tic.moveRelSteps(200)
+    tic.moveRelSteps(800)
     wait_for_motor(tic)
 
     print('Updating accel/decel + moving to position 0.')
-    print('NOTE: Movement confirms that microstepping is behaving properly.')
     sleep(1)
-    tic.accel_decel = tic.accel_decel * 8
+    tic.accel_decel = [0x70000000, 0x70000000]
     tic.moveAbsDist(0)
     wait_for_motor(tic)
 
-    print('Moving 10 revolutions clockwise at max recommended speed.')
+    print('Moving 20 revolutions clockwise at max recommended speed.')
     sleep(1)
     tic.dist_per_min = 200
-    tic.moveRelDist(10)
+    tic.moveRelDist(20)
     wait_for_motor(tic)
 
     print('Moving to position 0 + evaluating stop command')
     tic.moveAbsDist(0)
-    sleep(1)
+    sleep(2)
     tic.stop()
     wait_for_motor(tic)
 
@@ -65,10 +68,13 @@ def eval_tic(tic: pymotors.TicStepper):
 
 def wait_for_motor(motor):
     """Wait for motor to finish moving."""
+    sleep(.1)
     while motor.isMoving():
-        pass
+        sleep(.2)
+#        print('Current position: {}'.format(motor._position_in_steps()))
+        sleep(.1)
 
 
 if __name__ == '__main__':
-    TIC = pymotors.TicStepper('I2C', '/dev/i2c-0', 14)
+    TIC = pymotors.TicStepper('I2C', 1, 14)
     eval_tic(TIC)

--- a/tests/raspi_testing.py
+++ b/tests/raspi_testing.py
@@ -1,0 +1,74 @@
+from time import sleep
+import pymotors
+
+
+def eval_tic(tic: pymotors.TicStepper):
+    """Short testing script to confirm functionality."""
+    print('Tape on the motor shaft will help visualize motion.')
+    print('Motor will begin moving shortly. Press `CTL-C` to abort.')
+    print('Beginning in:')
+    print('3')
+    sleep(1)
+    print('2')
+    sleep(1)
+    print('1')
+    sleep(1)
+
+    print('Enabling motor.')
+    sleep(1)
+    tic.enable = True
+
+    print('Moving clockwise at default speed for 100 steps.')
+    sleep(1)
+    tic.moveAbsSteps(100)
+    wait_for_motor(tic)
+
+    print('Changing velocity to 10 RPM + moving 200 steps counter clockwise.')
+    sleep(1)
+    tic.rpm = 10
+    tic.moveRelSteps(-200)
+    wait_for_motor(tic)
+
+    print('Changing microsteps to 1/8 + moving 200 steps clockwise.')
+    print('NOTE: Speed should not change when using microsteps.')
+    sleep(1)
+    tic.microsteps = 1/8
+    tic.moveRelSteps(200)
+    wait_for_motor(tic)
+
+    print('Updating accel/decel + moving to position 0.')
+    print('NOTE: Movement confirms that microstepping is behaving properly.')
+    sleep(1)
+    tic.accel_decel = tic.accel_decel * 8
+    tic.moveAbsDist(0)
+    wait_for_motor(tic)
+
+    print('Moving 10 revolutions clockwise at max recommended speed.')
+    sleep(1)
+    tic.dist_per_min = 200
+    tic.moveRelDist(10)
+    wait_for_motor(tic)
+
+    print('Moving to position 0 + evaluating stop command')
+    tic.moveAbsDist(0)
+    sleep(1)
+    tic.stop()
+    wait_for_motor(tic)
+
+    print('Resuming movement to position 0')
+    tic.moveAbsDist(0)
+    wait_for_motor(tic)
+
+    print('De-energizing.')
+    tic.enable = False
+
+
+def wait_for_motor(motor):
+    """Wait for motor to finish moving."""
+    while motor.isMoving():
+        pass
+
+
+if __name__ == '__main__':
+    TIC = pymotors.TicStepper('I2C', '/dev/i2c-0', 14)
+    eval_tic(TIC)

--- a/tests/test_tic_stepper.py
+++ b/tests/test_tic_stepper.py
@@ -306,11 +306,6 @@ class TicStepperSer(unittest.TestCase):
         data_in = self.proc(operation[0], split_input)
         self.write.assert_called_with(data_in)
 
-    def test_accel_decel(self):
-        ac_dc_val = [1000, 10000]
-        self.tic.accel_decel = ac_dc_val
-        self.assertEqual(ac_dc_val, self.tic.accel_decel)
-
 
 def split32BitI2c(data_in):
     data_in = int(data_in)

--- a/tests/test_tic_stepper.py
+++ b/tests/test_tic_stepper.py
@@ -1,11 +1,14 @@
+"""Pololu Tic stepper driver unit tests."""
 import unittest
 from unittest.mock import patch
 import warnings
 import pymotors
 import tests.fake_smbus2 as fake_smbus2
+# pylint: disable=protected-access
+# pylint: disable=missing-docstring
 
 
-class TicI2c_Utilities(unittest.TestCase):
+class TicI2cUtilities(unittest.TestCase):
 
     @patch.object(pymotors.tic_stepper.TicI2C, '__init__', return_value=None)
     def setUp(self, mockInit):
@@ -46,17 +49,17 @@ class TicI2c_Utilities(unittest.TestCase):
         self.assertEqual(self.stepper.bus.fake_register_output, output)
 
     @patch('pymotors.tic_stepper.i2c_msg')
-    def test_fake_32_processing(self, mockI2c):
-        mockI2c.write = fake_smbus2.i2c_msg.write
+    def test_fake_32_processing(self, mock_i2c):
+        mock_i2c.write = fake_smbus2.i2c_msg.write
         payload = 0x7FFFFFFF
         offset = 0xBB
         address = self.stepper.address
         self.stepper.send([offset, 32], payload)
-        input = self.stepper.bus.fakeInput()
-        self.assertEqual([address, [offset, 0xFF, 0xFF, 0xFF, 0x7F]], input)
+        data_in = self.stepper.bus.fakeInput()
+        self.assertEqual([address, [offset, 0xFF, 0xFF, 0xFF, 0x7F]], data_in)
 
 
-class TicSerial_Utilities(unittest.TestCase):
+class TicSerialUtilities(unittest.TestCase):
     @patch('pymotors.tic_stepper.serial')
     def setUp(self, MockSerial):
         port_name = '/dev/ttyacm0'
@@ -132,7 +135,7 @@ class TicSerial_Utilities(unittest.TestCase):
         self.stepper.port.read.assert_called_with(variable[1])
 
 
-class TicStepper_I2c(unittest.TestCase):
+class TicStepperI2c(unittest.TestCase):
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     @patch('pymotors.tic_stepper.SMBus', new=fake_smbus2.SMBus)
     def setUp(self):
@@ -144,60 +147,60 @@ class TicStepper_I2c(unittest.TestCase):
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     def test_set_microstep(self):
         self.tic.microsteps = 1/8
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual([self.cmd['sStepMode'][0], 3], input[1])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual([self.cmd['sStepMode'][0], 3], data_in[1])
         micros = self.tic.microsteps
         self.assertEqual(1/8, micros)
         self.tic.microsteps = 1/4
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual([self.cmd['sStepMode'][0], 2], input[1])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual([self.cmd['sStepMode'][0], 2], data_in[1])
         self.tic.microsteps = 1/2
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual([self.cmd['sStepMode'][0], 1], input[1])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual([self.cmd['sStepMode'][0], 1], data_in[1])
         self.tic.microsteps = 1
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual([self.cmd['sStepMode'][0], 0], input[1])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual([self.cmd['sStepMode'][0], 0], data_in[1])
         try:
             warned = False
             self.tic.microsteps = 1/6
-            input = self.tic.com.bus.fakeInput()
+            data_in = self.tic.com.bus.fakeInput()
         except UserWarning:
             warned = True
         self.assertEqual(True, warned)
 
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     def test_steps_per_second(self):
-        self.tic.steps_per_second = .01
-        input = self.tic.com.bus.fakeInput()
-        split_input = split32BitI2c(self.tic.steps_per_second * 10000)
-        self.assertEqual([self.cmd['sMaxSpeed'][0]] + split_input[:], input[1])
+        self.tic.rpm = .1
+        data_in = self.tic.com.bus.fakeInput()
+        split_input = split32BitI2c(self.tic.rpm * 10000 / 60)
+        self.assertEqual([self.cmd['sMaxSpeed'][0]] + split_input[:], data_in[1])
 
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     def test_enable(self):
         self.tic.enable = True
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual(self.cmd['exitSafeStart'][0], input[1][0])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual(self.cmd['exitSafeStart'][0], data_in[1][0])
         self.assertEqual(True, self.tic.enable)
         self.tic.enable = False
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual(self.cmd['deenergize'][0], input[1][0])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual(self.cmd['deenergize'][0], data_in[1][0])
         self.assertEqual(False, self.tic.enable)
 
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     def test_move(self):
         self.tic.enable = True
         self.tic.moveAbsSteps(1000)
-        input = self.tic.com.bus.fakeInput()
+        data_in = self.tic.com.bus.fakeInput()
         split_input = split32BitI2c(1000)
-        self.assertEqual([self.cmd['sTargetPosition'][0]] + split_input, input[1])
+        self.assertEqual([self.cmd['sTargetPosition'][0]] + split_input, data_in[1])
 
     @patch('pymotors.tic_stepper.i2c_msg', new=fake_smbus2.i2c_msg)
     def test_is_homed(self):
         not_home = 3
         self.tic.com.bus.fake_register_output = not_home
         check_home = self.tic.isHomed()
-        input = self.tic.com.bus.fakeInput()
-        self.assertEqual(self.var['misc_flags1'][0], input[1])
+        data_in = self.tic.com.bus.fakeInput()
+        self.assertEqual(self.var['misc_flags1'][0], data_in[1])
         self.assertEqual(False, check_home)
         is_home = 1
         self.tic.com.bus.fake_register_output = is_home
@@ -205,7 +208,7 @@ class TicStepper_I2c(unittest.TestCase):
         self.assertEqual(True, check_home)
 
 
-class TicStepper_Ser(unittest.TestCase):
+class TicStepperSer(unittest.TestCase):
     @patch('pymotors.tic_stepper.serial')
     def setUp(self, MockSerial):
         port_name = '/dev/ttyacm0'
@@ -223,19 +226,19 @@ class TicStepper_Ser(unittest.TestCase):
     def test_set_microstep(self):
         operation = self.cmd['sStepMode']
         self.tic.microsteps = 1/8
-        input = self.proc(operation[0], [3])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], [3])
+        self.write.assert_called_with(data_in)
         micros = self.tic.microsteps
         self.assertEqual(1/8, micros)
         self.tic.microsteps = 1/4
-        input = self.proc(operation[0], [2])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], [2])
+        self.write.assert_called_with(data_in)
         self.tic.microsteps = 1/2
-        input = self.proc(operation[0], [1])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], [1])
+        self.write.assert_called_with(data_in)
         self.tic.microsteps = 1
-        input = self.proc(operation[0], [0])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], [0])
+        self.write.assert_called_with(data_in)
         try:
             warned = False
             self.tic.microsteps = 1/6
@@ -245,22 +248,22 @@ class TicStepper_Ser(unittest.TestCase):
 
     def test_steps_per_second(self):
         operation = self.cmd['sMaxSpeed']
-        data = .01
-        self.tic.steps_per_second = data
-        split_input = split32BitSer(data * 10000)
-        input = self.proc(operation[0], split_input)
-        self.write.assert_called_with(input)
+        data = 2
+        self.tic.rpm = data
+        split_input = split32BitSer(data * 10000 / 60)
+        data_in = self.proc(operation[0], split_input)
+        self.write.assert_called_with(data_in)
 
     def test_enable(self):
         operation = self.cmd['exitSafeStart']
         self.tic.enable = True
-        input = self.proc(operation[0])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0])
+        self.write.assert_called_with(data_in)
         self.assertEqual(True, self.tic.enable)
         self.tic.enable = False
         operation = self.cmd['deenergize']
-        input = self.proc(operation[0])
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0])
+        self.write.assert_called_with(data_in)
         self.assertEqual(False, self.tic.enable)
 
     def test_move(self):
@@ -269,8 +272,8 @@ class TicStepper_Ser(unittest.TestCase):
         steps = 1000
         self.tic.moveAbsSteps(steps)
         split_input = split32BitSer(steps)
-        input = self.proc(operation[0], split_input)
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], split_input)
+        self.write.assert_called_with(data_in)
 
     def test_is_homed(self):
         operation = self.cmd['gVariable']
@@ -278,8 +281,8 @@ class TicStepper_Ser(unittest.TestCase):
         not_home = [3]
         self.read.return_value = not_home
         check_home = self.tic.isHomed()
-        input = self.proc(operation[0], variable)
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], variable)
+        self.write.assert_called_with(data_in)
         self.read.assert_called_with(variable[1])
         self.assertEqual(False, check_home)
         is_home = [1]
@@ -292,36 +295,42 @@ class TicStepper_Ser(unittest.TestCase):
         self.tic._setAccel(ac_val)
         operation = self.cmd['sMaxAccel']
         split_input = split32BitSer(ac_val)
-        input = self.proc(operation[0], split_input)
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], split_input)
+        self.write.assert_called_with(data_in)
 
     def test_set_decel(self):
         dc_val = 1000001
         self.tic._setDecel(dc_val)
         operation = self.cmd['sMaxDecel']
         split_input = split32BitSer(dc_val)
-        input = self.proc(operation[0], split_input)
-        self.write.assert_called_with(input)
+        data_in = self.proc(operation[0], split_input)
+        self.write.assert_called_with(data_in)
 
-def split32BitI2c(input):
-    input = int(input)
-    output = [input >> 0 & 0xFF,
-              input >> 8 & 0xFF,
-              input >> 16 & 0xFF,
-              input >> 24 & 0xFF]
+    def test_accel_decel(self):
+        ac_dc_val = [1000, 10000]
+        self.tic.accel_decel = ac_dc_val
+        self.assertEqual(ac_dc_val, self.tic.accel_decel)
+
+
+def split32BitI2c(data_in):
+    data_in = int(data_in)
+    output = [data_in >> 0 & 0xFF,
+              data_in >> 8 & 0xFF,
+              data_in >> 16 & 0xFF,
+              data_in >> 24 & 0xFF]
     return output
 
 
-def split32BitSer(input):
-    input = int(input)
-    output = [((input >> 7) & 1)
-              | ((input >> 14) & 2)
-              | ((input >> 21) & 4)
-              | ((input >> 28) & 8),
-              input >> 0 & 0x7F,
-              input >> 8 & 0x7F,
-              input >> 16 & 0x7F,
-              input >> 24 & 0x7F]
+def split32BitSer(data_in):
+    data_in = int(data_in)
+    output = [((data_in >> 7) & 1)
+              | ((data_in >> 14) & 2)
+              | ((data_in >> 21) & 4)
+              | ((data_in >> 28) & 8),
+              data_in >> 0 & 0x7F,
+              data_in >> 8 & 0x7F,
+              data_in >> 16 & 0x7F,
+              data_in >> 24 & 0x7F]
     return output
 
 


### PR DESCRIPTION
User no longer needs to consider order of executing operations to propagate new microstep settings in stepper motor objects.

Awkward speed settings have been changed to a more common format: RPM and distance per min (such as 120 mm / min).

Documentation has been extended to help new users.

Script for testing TicStepper methods on a Raspberry Pi over I2C has also been added.